### PR TITLE
Add flashcards web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# codex101
+# Flashcards App
+
+## Setup
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+flask --app flashcards/app run
+```
+

--- a/flashcards/__init__.py
+++ b/flashcards/__init__.py
@@ -1,0 +1,2 @@
+from .app import create_app
+

--- a/flashcards/app.py
+++ b/flashcards/app.py
@@ -1,0 +1,126 @@
+import os
+from flask import Flask, render_template, redirect, url_for, flash, request
+from .config import Config
+from .models import db, FlashCard, Lesson, lesson_cards
+from .forms import CardForm, LessonForm, ScoreForm
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    @app.route('/')
+    def index():
+        return redirect(url_for('lesson_list'))
+
+    @app.route('/cards')
+    def card_list():
+        cards = FlashCard.query.all()
+        return render_template('card_list.html', cards=cards)
+
+    @app.route('/cards/new', methods=['GET', 'POST'])
+    def card_new():
+        form = CardForm()
+        if form.validate_on_submit():
+            card = FlashCard(front_text=form.front_text.data, back_text=form.back_text.data)
+            db.session.add(card)
+            db.session.commit()
+            return redirect(url_for('card_list'))
+        if form.errors:
+            flash('Error creating card')
+        return render_template('card_form.html', form=form)
+
+    @app.route('/cards/<int:id>/edit', methods=['GET', 'POST'])
+    def card_edit(id):
+        card = FlashCard.query.get_or_404(id)
+        form = CardForm(obj=card)
+        if form.validate_on_submit():
+            card.front_text = form.front_text.data
+            card.back_text = form.back_text.data
+            db.session.commit()
+            return redirect(url_for('card_list'))
+        if form.errors:
+            flash('Error updating card')
+        return render_template('card_form.html', form=form)
+
+    @app.route('/lessons')
+    def lesson_list():
+        lessons = Lesson.query.order_by(Lesson.created_at.desc()).all()
+        return render_template('lesson_list.html', lessons=lessons)
+
+    @app.route('/lessons/new', methods=['GET', 'POST'])
+    def lesson_new():
+        form = LessonForm()
+        cards = FlashCard.query.all()
+        form.cards.choices = [(c.id, c.front_text) for c in cards]
+        selected = [c.id for c in cards]
+        if form.validate_on_submit():
+            lesson = Lesson(title=form.title.data)
+            db.session.add(lesson)
+            db.session.flush()
+            order_ids = [int(i) for i in form.order.data.split(',') if i]
+            selected_ids = [int(cid) for cid in request.form.getlist('cards')]
+            order_map = {cid: idx for idx, cid in enumerate(order_ids)}
+            for cid in selected_ids:
+                db.session.execute(lesson_cards.insert().values(
+                    lesson_id=lesson.id, card_id=cid,
+                    order_index=order_map.get(cid, 0), last_score=None))
+            db.session.commit()
+            return redirect(url_for('lesson_list'))
+        return render_template('lesson_form.html', form=form, cards=cards, selected=selected)
+
+    def get_lesson_cards(lesson):
+        stmt = db.select(FlashCard, lesson_cards.c.last_score).join(lesson_cards).where(
+            lesson_cards.c.lesson_id == lesson.id).order_by(lesson_cards.c.order_index)
+        return db.session.execute(stmt).all()
+
+    @app.route('/lessons/<int:id>/run', methods=['GET', 'POST'])
+    def run_lesson(id):
+        lesson = Lesson.query.get_or_404(id)
+        cards_with_scores = get_lesson_cards(lesson)
+        index = int(request.args.get('i', 0))
+        if index >= len(cards_with_scores):
+            return redirect(url_for('lesson_summary', id=lesson.id))
+        card, score = cards_with_scores[index]
+        form = ScoreForm()
+        if form.validate_on_submit():
+            db.session.execute(lesson_cards.update().where(
+                (lesson_cards.c.lesson_id == lesson.id) & (lesson_cards.c.card_id == int(form.card_id.data)))
+                .values(last_score=int(form.score.data)))
+            db.session.commit()
+            return redirect(url_for('run_lesson', id=lesson.id, i=index + 1))
+        return render_template('run_lesson.html', lesson=lesson, card=card, form=form)
+
+    @app.route('/lessons/<int:id>/summary')
+    def lesson_summary(id):
+        lesson = Lesson.query.get_or_404(id)
+        results = get_lesson_cards(lesson)
+        return render_template('lesson_summary.html', lesson=lesson, results=results)
+
+    @app.route('/lessons/<int:id>/summary', methods=['POST'])
+    def create_next_lesson(id):
+        lesson = Lesson.query.get_or_404(id)
+        cards = [card for card, score in get_lesson_cards(lesson) if score is not None and score <= 3]
+        if not cards:
+            flash('No cards scored 3 or below')
+            return redirect(url_for('lesson_summary', id=id))
+        new_lesson = Lesson(title=f"Follow-up to {lesson.title}")
+        db.session.add(new_lesson)
+        db.session.flush()
+        for idx, card in enumerate(cards):
+            db.session.execute(lesson_cards.insert().values(
+                lesson_id=new_lesson.id, card_id=card.id, order_index=idx, last_score=None))
+        db.session.commit()
+        return redirect(url_for('run_lesson', id=new_lesson.id))
+
+    return app
+
+if __name__ == '__main__':
+    debug = os.environ.get('FLASK_ENV') == 'development'
+    app = create_app()
+    app.run(debug=debug)
+

--- a/flashcards/config.py
+++ b/flashcards/config.py
@@ -1,0 +1,9 @@
+import os
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL',
+        'sqlite:///' + os.path.join(BASE_DIR, 'flashcards.db'))
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/flashcards/forms.py
+++ b/flashcards/forms.py
@@ -1,0 +1,18 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SubmitField, SelectMultipleField, HiddenField
+from wtforms.validators import DataRequired
+
+class CardForm(FlaskForm):
+    front_text = TextAreaField('Front', validators=[DataRequired()])
+    back_text = TextAreaField('Back', validators=[DataRequired()])
+    submit = SubmitField('Save')
+
+class LessonForm(FlaskForm):
+    title = StringField('Title', validators=[DataRequired()])
+    cards = SelectMultipleField('Cards', coerce=int)
+    order = HiddenField('Order')
+    submit = SubmitField('Save')
+
+class ScoreForm(FlaskForm):
+    card_id = HiddenField('Card ID', validators=[DataRequired()])
+    score = HiddenField('Score', validators=[DataRequired()])

--- a/flashcards/models.py
+++ b/flashcards/models.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+lesson_cards = db.Table(
+    'lesson_cards',
+    db.Column('lesson_id', db.Integer, db.ForeignKey('lesson.id'), primary_key=True),
+    db.Column('card_id', db.Integer, db.ForeignKey('flash_card.id'), primary_key=True),
+    db.Column('order_index', db.Integer, default=0),
+    db.Column('last_score', db.Integer)
+)
+
+class FlashCard(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    front_text = db.Column(db.Text, nullable=False)
+    back_text = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+class Lesson(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(120), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    cards = db.relationship('FlashCard', secondary=lesson_cards,
+                            backref=db.backref('lessons', lazy='dynamic'),
+                            order_by=lesson_cards.c.order_index)

--- a/flashcards/static/main.css
+++ b/flashcards/static/main.css
@@ -1,0 +1,5 @@
+#flashcard {cursor:pointer;transition:transform 0.6s;}
+#flashcard.flipped {transform:rotateY(180deg);}
+#flashcard .card-body {min-height:100px;display:flex;align-items:center;justify-content:center;font-size:1.25rem;}
+button{min-height:44px;}
+@media (prefers-color-scheme: dark){body{background-color:#121212;color:#fff;}}

--- a/flashcards/templates/base.html
+++ b/flashcards/templates/base.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Flashcards{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('lesson_list') }}">Flashcards</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('lesson_list') }}">Lessons</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('card_list') }}">Cards</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="alert alert-warning">
+        {% for msg in messages %}{{ msg }}<br>{% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+  {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/flashcards/templates/card_form.html
+++ b/flashcards/templates/card_form.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block title %}Edit Card{% endblock %}
+{% block content %}
+<h1>{{ 'Edit' if form.front_text.data else 'New' }} Card</h1>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.front_text.label(class="form-label") }}
+    {{ form.front_text(class="form-control", rows=3) }}
+  </div>
+  <div class="mb-3">
+    {{ form.back_text.label(class="form-label") }}
+    {{ form.back_text(class="form-control", rows=3) }}
+  </div>
+  {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/flashcards/templates/card_list.html
+++ b/flashcards/templates/card_list.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Cards{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between mb-2">
+  <h1>Cards</h1>
+  <a class="btn btn-primary" href="{{ url_for('card_new') }}">New Card</a>
+</div>
+<table class="table">
+<thead><tr><th>Front</th><th>Back</th><th></th></tr></thead>
+<tbody>
+{% for card in cards %}
+<tr>
+  <td>{{ card.front_text }}</td>
+  <td>{{ card.back_text }}</td>
+  <td><a class="btn btn-sm btn-secondary" href="{{ url_for('card_edit', id=card.id) }}">Edit</a></td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}

--- a/flashcards/templates/lesson_form.html
+++ b/flashcards/templates/lesson_form.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block title %}New Lesson{% endblock %}
+{% block content %}
+<h1>New Lesson</h1>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.title.label(class="form-label") }}
+    {{ form.title(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Select Cards</label>
+    <ul id="card-list" class="list-group">
+    {% for card in cards %}
+      <li class="list-group-item">
+        <input class="form-check-input me-1" type="checkbox" name="cards" value="{{ card.id }}" id="card{{ card.id }}"
+               {% if card.id in selected %}checked{% endif %}>
+        <label class="form-check-label" for="card{{ card.id }}">{{ card.front_text }}</label>
+      </li>
+    {% endfor %}
+    </ul>
+  </div>
+  {{ form.order(id='order-field') }}
+  {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}
+{% block scripts %}
+<script>
+  const list = document.getElementById('card-list');
+  list.addEventListener('dragstart', e => { e.target.classList.add('dragging'); });
+  list.addEventListener('dragend', e => { e.target.classList.remove('dragging'); updateOrder(); });
+  list.querySelectorAll('li').forEach(li => { li.draggable = true; });
+  list.addEventListener('dragover', e => {
+    e.preventDefault();
+    const dragging = document.querySelector('.dragging');
+    const after = Array.from(list.children).find(child => child !== dragging && e.clientY <= child.getBoundingClientRect().top + child.offsetHeight/2);
+    if(after==null) list.appendChild(dragging); else list.insertBefore(dragging, after);
+  });
+  function updateOrder(){
+    const ids = Array.from(list.children).map(li => li.querySelector('input').value);
+    document.getElementById('order-field').value = ids.join(',');
+  }
+  updateOrder();
+</script>
+{% endblock %}

--- a/flashcards/templates/lesson_list.html
+++ b/flashcards/templates/lesson_list.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block title %}Lessons{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between mb-2">
+  <h1>Lessons</h1>
+  <a class="btn btn-primary" href="{{ url_for('lesson_new') }}">New Lesson</a>
+</div>
+<table class="table">
+<thead><tr><th>Title</th><th>Created</th><th></th></tr></thead>
+<tbody>
+{% for lesson in lessons %}
+<tr>
+  <td>{{ lesson.title }}</td>
+  <td>{{ lesson.created_at.strftime('%Y-%m-%d') }}</td>
+  <td>
+    <a class="btn btn-sm btn-success" href="{{ url_for('run_lesson', id=lesson.id) }}">Run</a>
+  </td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}

--- a/flashcards/templates/lesson_summary.html
+++ b/flashcards/templates/lesson_summary.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block title %}Lesson Summary{% endblock %}
+{% block content %}
+<h1>{{ lesson.title }} - Summary</h1>
+<table class="table">
+<thead><tr><th>Card</th><th>Score</th></tr></thead>
+<tbody>
+{% for card, score in results %}
+<tr>
+  <td>{{ card.front_text }}</td>
+  <td>{{ score }}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+<form method="post" action="{{ url_for('create_next_lesson', id=lesson.id) }}">
+  <button type="submit" class="btn btn-primary">Create Next Lesson</button>
+</form>
+{% endblock %}

--- a/flashcards/templates/run_lesson.html
+++ b/flashcards/templates/run_lesson.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}Run Lesson{% endblock %}
+{% block content %}
+<h1>{{ lesson.title }}</h1>
+<div class="card mb-3" id="flashcard">
+  <div class="card-body">
+    <div id="front">{{ card.front_text }}</div>
+    <div id="back" class="d-none">{{ card.back_text }}</div>
+  </div>
+</div>
+<form method="post" id="score-form">
+  {{ form.hidden_tag() }}
+  {{ form.card_id(value=card.id) }}
+  {{ form.score(id='score-field') }}
+  <div class="btn-group" role="group">
+    {% for i in range(1,6) %}
+      <button type="button" class="btn btn-outline-primary" onclick="rate({{ i }})">{{ i }}</button>
+    {% endfor %}
+  </div>
+</form>
+{% endblock %}
+{% block scripts %}
+<script>
+const cardEl=document.getElementById('flashcard');
+const front=document.getElementById('front');
+const back=document.getElementById('back');
+cardEl.addEventListener('click',()=>{front.classList.toggle('d-none');back.classList.toggle('d-none');cardEl.classList.toggle('flipped');});
+function rate(v){document.getElementById('score-field').value=v;document.getElementById('score-form').submit();}
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask>=3.0
+Flask-WTF
+SQLAlchemy
+Flask-SQLAlchemy
+WTForms
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,35 @@
+import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from flashcards.app import create_app
+from flashcards.models import db, FlashCard, Lesson, lesson_cards
+
+class ModelTestCase(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app()
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+        self.app.config['TESTING'] = True
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+        db.create_all()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+        self.ctx.pop()
+
+    def test_card_lesson_relation(self):
+        card = FlashCard(front_text='front', back_text='back')
+        db.session.add(card)
+        lesson = Lesson(title='Lesson1')
+        db.session.add(lesson)
+        db.session.commit()
+        db.session.execute(lesson_cards.insert().values(lesson_id=lesson.id, card_id=card.id, order_index=0))
+        db.session.commit()
+        self.assertEqual(lesson.cards[0].id, card.id)
+        self.assertEqual(card.lessons.first().id, lesson.id)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement Flask flashcards app with lessons and scoring
- add WTForms forms and SQLAlchemy models
- provide Bootstrap-powered templates and CSS
- include setup instructions and unit test

## Testing
- `python -m pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e31ad300832ca02fba34848e0aff